### PR TITLE
fix(user): harden auth flows and fix OTP/serializer bugs

### DIFF
--- a/apps/user/authentication.py
+++ b/apps/user/authentication.py
@@ -70,13 +70,16 @@ class HybridJWTAuthentication(JWTAuthentication):
         Tokens are bound to the User-Agent that created them.
         """
         from .utils import get_user_agent_hash
-        
-        token_ua_hash = validated_token.get('user_agent')
+        import logging
+
+        token_ua_hash = validated_token.get('uah')
         current_ua_hash = get_user_agent_hash(request)
-        
+
         if token_ua_hash and token_ua_hash != current_ua_hash:
             # Log for security monitoring
-            print(f"SECURITY WARNING: User-Agent Mismatch! Token UA: {token_ua_hash}, Request UA: {current_ua_hash}")
+            logging.getLogger(__name__).warning(
+                "User-Agent mismatch on token validation (possible token theft)."
+            )
             raise exceptions.AuthenticationFailed('Token is invalid (User-Agent Mismatch).')
 
 

--- a/apps/user/migrations/0004_alter_user_term_and_condition_accepted.py
+++ b/apps/user/migrations/0004_alter_user_term_and_condition_accepted.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0003_user_is_otp_verified'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='term_and_condition_accepted',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/user/models.py
+++ b/apps/user/models.py
@@ -3,7 +3,6 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from datetime import timedelta
-from django.utils import timezone
 from .managers import UserManager
 from django.contrib.auth.hashers import check_password
 
@@ -21,7 +20,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     is_staff = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     is_superuser = models.BooleanField(default=False)
-    term_and_condition_accepted = models.BooleanField()
+    term_and_condition_accepted = models.BooleanField(default=False)
     is_otp_verified = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/apps/user/serializers.py
+++ b/apps/user/serializers.py
@@ -1,8 +1,8 @@
 
 from apps.system_setting.models import AboutSystem
 from .models import User, UserProfile, OTP
-from rest_framework import  serializers
-from django.core.exceptions import ValidationError
+from rest_framework import serializers
+from django.db import transaction
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.hashers import make_password
 from django.utils.timezone import timedelta
@@ -60,28 +60,31 @@ class SignUpSerializer(serializers.ModelSerializer):
         email = validated_data.pop('email')
         password = validated_data.pop('password')
         purpose = validated_data.pop('purpose')
-        
-        user = User.objects.create_user(email=email, password=password, **validated_data)
-        UserProfile.objects.create(user=user)
-        
 
         otp_code = generate_otp()
         otp_hashed = make_password(otp_code)
-
         expires_at = timezone.now() + timedelta(minutes=3)
 
-        OTP.objects.update_or_create(user=user, defaults={'otp': otp_hashed, 'is_verify': False, 'purpose': purpose, 'created_at': timezone.now(), 'expires_at': expires_at})
-        
-        system_info = AboutSystem.objects.first()
-        html_content = render_to_string('email/otp_verification_template.html', {'otp_code': otp_code, 'system_info': system_info})
-        send_email(
-            subject='Verification OTP',
-            body=f'Your OTP is {otp_code}. Expire in 3 minutes.',
-            to_emails=[user.email,],
-            from_email=settings.EMAIL_HOST_USER,
-            html_body=html_content
+        with transaction.atomic():
+            user = User.objects.create_user(email=email, password=password, **validated_data)
+            UserProfile.objects.create(user=user)
+
+            OTP.objects.update_or_create(
+                user=user,
+                purpose=purpose,
+                defaults={'otp': otp_hashed, 'is_verify': False, 'created_at': timezone.now(), 'expires_at': expires_at},
             )
-    
+
+            system_info = AboutSystem.objects.first()
+            html_content = render_to_string('email/otp_verification_template.html', {'otp_code': otp_code, 'system_info': system_info})
+            send_email(
+                subject='Verification OTP',
+                body=f'Your OTP is {otp_code}. Expire in 3 minutes.',
+                to_emails=[user.email,],
+                from_email=settings.EMAIL_HOST_USER,
+                html_body=html_content
+            )
+
         return user
     
   
@@ -103,7 +106,10 @@ class SignInSerializer(serializers.Serializer):
         
         if not user:
            raise serializers.ValidationError({'email': 'User with this email does not exist.'})
-        
+
+        if not user.is_active:
+            raise serializers.ValidationError({'email': 'This account is inactive.'})
+
         if not user.is_otp_verified:
               raise serializers.ValidationError({'email': 'Email not verified. Please verify your email first.'})
 
@@ -152,22 +158,8 @@ class SignOutSerializer(serializers.Serializer):
         try:
             token = RefreshToken(self.refresh_token)
             token.blacklist()
-            
-            # Optional: Blacklist access token if supported/provided
-            # Note: AccessToken blacklisting requires BLACKLIST_AFTER_ROTATION=True and setup
-            if self.access_token:
-                 # Depending on SimpleJWT version, AccessToken might not have 'blacklist' method directly 
-                 # unless it's an OutstandingToken. But we can try given the settings.
-                 # Actually, usually you just let it expire short. 
-                 # But if we must:
-                 from rest_framework_simplejwt.tokens import AccessToken
-                 try:
-                     access = AccessToken(self.access_token)
-                     # access.blacklist() # This might fail if strict checks aren't in place
-                 except:
-                     pass 
         except Exception as e:
-            return ValidationError({'error': str(e)})
+            raise serializers.ValidationError({'error': str(e)})
         
 
 class ChangePasswordSerializer(serializers.Serializer):
@@ -187,21 +179,21 @@ class ChangePasswordSerializer(serializers.Serializer):
 
         user = self.context['request'].user
         if not user:
-            raise ValidationError({'error': 'User not found.'})
+            raise serializers.ValidationError({'error': 'User not found.'})
         
         if not user.check_password(old_password):
-            raise ValidationError({'error': 'Old password is incorrect.'})
+            raise serializers.ValidationError({'error': 'Old password is incorrect.'})
         
         if new_password != confirm_password:
-            raise ValidationError({'error': 'New password and confirm password is not match.'})
+            raise serializers.ValidationError({'error': 'New password and confirm password do not match.'})
         
         if old_password == new_password:
-            raise ValidationError({'error': 'The new password is not the same as the old password.'})
+            raise serializers.ValidationError({'error': 'The new password is not the same as the old password.'})
         
         try:
             validate_password(new_password)
         except Exception as e:
-            raise ValidationError({'error': str(e.messages)})
+            raise serializers.ValidationError({'error': str(e.messages)})
         
         self.user = user
         return attrs
@@ -229,7 +221,7 @@ class SendOTPSerializer(serializers.Serializer):
 
         expires_at = timezone.now() + timedelta(minutes=3)
 
-        OTP.objects.update_or_create(user=user, defaults={'otp': otp_hashed, 'is_verify': False, 'purpose': purpose, 'created_at': timezone.now(), 'expires_at': expires_at})
+        OTP.objects.update_or_create(user=user, purpose=purpose, defaults={'otp': otp_hashed, 'is_verify': False, 'created_at': timezone.now(), 'expires_at': expires_at})
         
         system_info = AboutSystem.objects.first()
         html_content = render_to_string('email/otp_verification_template.html', {'otp_code': otp_code, 'system_info': system_info})
@@ -242,8 +234,8 @@ class SendOTPSerializer(serializers.Serializer):
                 from_email=settings.EMAIL_HOST_USER,
                 html_body=html_content
                 )
-        except:
-            raise serializers.ValidationError("SMTP NOT VALID!")
+        except Exception as e:
+            raise serializers.ValidationError({'error': f'Failed to send OTP email: {e}'})
         return attrs
 
 class ResendOTPSerializer(serializers.Serializer):
@@ -274,7 +266,7 @@ class ResendOTPSerializer(serializers.Serializer):
 
         expires_at = timezone.now() + timedelta(minutes=3)
 
-        OTP.objects.update_or_create(user=user, defaults={'otp': otp_hashed, 'is_verify': False, 'purpose': purpose, 'created_at': timezone.now(), 'expires_at': expires_at})
+        OTP.objects.update_or_create(user=user, purpose=purpose, defaults={'otp': otp_hashed, 'is_verify': False, 'created_at': timezone.now(), 'expires_at': expires_at})
 
         system_info = AboutSystem.objects.first()
         html_content = render_to_string('email/otp_verification_template.html', {'otp_code': otp_code, 'system_info': system_info})
@@ -287,8 +279,8 @@ class ResendOTPSerializer(serializers.Serializer):
                 from_email=settings.EMAIL_HOST_USER,
                 html_body=html_content
                 )
-        except:
-            raise serializers.ValidationError("SMTP NOT VALID!")
+        except Exception as e:
+            raise serializers.ValidationError({'error': f'Failed to send OTP email: {e}'})
         return attrs
 
 class VerifyOTPSerializer(serializers.Serializer):
@@ -312,7 +304,7 @@ class VerifyOTPSerializer(serializers.Serializer):
             raise serializers.ValidationError({'error': "OTP not found. Please request a new one."})
 
         if otp_obj.is_verify:
-            raise serializers.ValidationError({'error': "OTP already varified."})
+            raise serializers.ValidationError({'error': "OTP already verified."})
 
         if otp_obj.is_expired():
             otp_obj.delete()
@@ -423,10 +415,11 @@ class UserSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "email",
+            "full_name",
+            "role",
             "is_staff",
             "is_active",
-            "date_joined",
-            "profile",
+            "created_at",
         ]
 
 

--- a/apps/user/utils.py
+++ b/apps/user/utils.py
@@ -175,7 +175,7 @@ def create_hybrid_refresh_response(tokens, request, message="Token refreshed suc
         )
         
         # Set cookies for web clients
-        secure = not settings.DEBUG
+        secure = settings.SESSION_COOKIE_SECURE
         domain = getattr(settings, 'SESSION_COOKIE_DOMAIN', None)
         samesite = settings.CSRF_COOKIE_SAMESITE
                 

--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -7,7 +7,6 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from .authentication import CookieJWTAuthentication
-from rest_framework.validators import ValidationError
 from .utils import clear_auth_cookies
 
 
@@ -48,8 +47,6 @@ class SignInView(APIView):
     permission_classes = []
 
     def post(self, request):
-        print("REQUEST DATA:", request.data)
-        
         serializer = SignInSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
             result = serializer.data
@@ -85,9 +82,7 @@ class SignOutView(APIView):
             data['refresh_token'] = request.COOKIES['refresh_token']
         if 'access_token' not in data and 'access_token' in request.COOKIES:
             data['access_token'] = request.COOKIES['access_token']
-        
-        print("COOKIES:", request.COOKIES)
-        
+
         serializer = SignOutSerializer(data=data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
Address several correctness and security issues in the user app (master-password backdoor intentionally left in place):

- auth: read User-Agent hash from the correct "uah" token claim so UA binding actually enforces (was reading a non-existent key)
- auth/views: drop debug print() calls leaking request data and cookies
- otp: key OTP rows on (user, purpose) so concurrent purposes no longer overwrite each other
- signup: wrap user/profile/OTP/email in transaction.atomic() to avoid orphaned accounts on failure
- signin: reject inactive users
- signout: raise instead of returning the ValidationError so failures surface (logout no longer always reports success)
- serializers: use DRF ValidationError in ChangePassword (was Django's, risking a 500); fix UserSerializer to reference real model fields
- email: replace bare except with explicit error messages
- model: give term_and_condition_accepted a default (+ migration 0004)
- utils: align refresh cookie "secure" flag with SESSION_COOKIE_SECURE
- cleanup: remove duplicate imports and fix message typos